### PR TITLE
국민연금 API 연동

### DIFF
--- a/src/main/java/com/juniorok/juniorok/config/ApiConfig.java
+++ b/src/main/java/com/juniorok/juniorok/config/ApiConfig.java
@@ -11,4 +11,7 @@ public class ApiConfig {
     @Value("${kakao.api.map.appkey}")
     String kakaoMapAppkey;
 
+    @Value("${data.go.kr.service_key}")
+    String dataGoKrServiceKey;
+
 }

--- a/src/main/java/com/juniorok/juniorok/domain/Company.java
+++ b/src/main/java/com/juniorok/juniorok/domain/Company.java
@@ -26,6 +26,7 @@ public class Company {
     private int developers;
     private long revenue;
     private long avgSalary;
+    private long businessNumber;
     private List<Address> addresses;
     private List<Skill> skills;
     private List<Benefit> benefits;

--- a/src/main/java/com/juniorok/juniorok/dto/JoinLeave.java
+++ b/src/main/java/com/juniorok/juniorok/dto/JoinLeave.java
@@ -10,10 +10,10 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class Address {
-    long id;
-    Company company;
-    String state;
-    String city;
-    String others;
+public class JoinLeave {
+    private Company company;
+    private int year;
+    private int month;
+    private int join;
+    private int leave;
 }

--- a/src/main/java/com/juniorok/juniorok/form/PostForm.java
+++ b/src/main/java/com/juniorok/juniorok/form/PostForm.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 public record PostForm (
         String companyName,
+        long businessNumber,
         String position,
         int jobType,
         String location,
@@ -26,6 +27,7 @@ public record PostForm (
     public static PostForm newInstance() {
         return new PostForm(
                 "",
+                0,
                 "",
                 0,
                 "",

--- a/src/main/java/com/juniorok/juniorok/openapi/NationalPensionApi.java
+++ b/src/main/java/com/juniorok/juniorok/openapi/NationalPensionApi.java
@@ -1,0 +1,144 @@
+package com.juniorok.juniorok.openapi;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.juniorok.juniorok.config.ApiConfig;
+import com.juniorok.juniorok.openapi.dto.BusinessBaseInfo;
+import com.juniorok.juniorok.openapi.dto.BusinessDetailInfo;
+import com.juniorok.juniorok.openapi.dto.JoinLeaveInfo;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Comparator;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Component
+public class NationalPensionApi {
+
+    private final ApiConfig apiConfig;
+    private final String API_BASE_URL = "http://apis.data.go.kr/B552015/NpsBplcInfoInqireService";
+    private final String BUSINESS_BASE_INFO_LIST_API_PATH = "/getBassInfoSearch";
+    private final String BUSINESS_DETAIL_PER_MONTH_API_PATH = "/getDetailInfoSearch";
+    private final String EMPLOYEE_JOIN_LEAVE_PER_MONTH_API_PATH = "/getPdAcctoSttusInfoSearch";
+    private final String REQUEST_SIZE = "50";
+
+    private BusinessDetailInfo businessDetailInfo;
+    private JoinLeaveInfo joinLeaveInfo;
+    private int recentSequenceNumber;
+    @Getter
+    private int recentYearAndMonth;
+
+    public int getRecentEmployees(long businessNumber, String companyName) {
+        requestBusinessInfo(businessNumber, companyName);
+        return businessDetailInfo.getBody().getItem().getEmployees();
+    }
+
+    public String getAddress(long businessNumber, String companyName) {
+        requestBusinessInfo(businessNumber, companyName);
+        return businessDetailInfo.getBody().getItem().getAddress();
+    }
+
+    public long getRecentAverageSalary(long businessNumber, String companyName) {
+        requestBusinessInfo(businessNumber, companyName);
+        return calculateAverageSalary();
+    }
+
+    private long calculateAverageSalary() {
+        int employees = businessDetailInfo.getBody().getItem().getEmployees();
+        return (long) (businessDetailInfo.getBody().getItem().getMonthlyAmount() / employees / 0.09 * 12);
+    }
+
+    public int getJoinCount(long businessNumber, String companyName) {
+        requestBusinessInfo(businessNumber, companyName);
+        requestJoinLeaveInfo(recentSequenceNumber);
+        return joinLeaveInfo.getBody().getItems().getItem().getJoin();
+    }
+
+    public int getLeaveCount(long businessNumber, String companyName) {
+        requestBusinessInfo(businessNumber, companyName);
+        requestJoinLeaveInfo(recentSequenceNumber);
+        return joinLeaveInfo.getBody().getItems().getItem().getLeave();
+    }
+
+    private void requestBusinessInfo(long businessNumber, String companyName) {
+        if (businessDetailInfo == null || !businessDetailInfo.getBody().getItem().getCompanyName().equals(companyName)) {
+            recentSequenceNumber = requestRecentSequenceNumber(businessNumber, companyName);
+            requestBusinessDetailInfo(recentSequenceNumber);
+        }
+    }
+
+    private int requestRecentSequenceNumber(long businessNumber, String companyName) {
+        String url = buildBusinessBaseInfoUrl(List.of(String.valueOf(businessNumber).substring(0, 6), companyName, "1", REQUEST_SIZE));
+        var xmlMapper = new XmlMapper();
+        JavaType type = xmlMapper.getTypeFactory().constructCollectionType(List.class, BusinessBaseInfo.class);
+        try {
+            List<BusinessBaseInfo> businessBaseInfoList = xmlMapper.readValue(new URL(url), type);
+
+            // 국민연금 API는 사업자명 검색 시 쿼리 파라미터에 포함된 문자열이 포함된 모든 사업자 정보를 제공합니다.
+            // 또한 같은 사업자명을 포함하면서 사업자번호가 앞 6자리는 같은 경우가 있어 바로 데이터를 적용하기에는 무리가 있습니다.
+            // 프로젝트 발표 기간이 얼마 남지 않아 임시적으로 적용을 하지만, 데이터베이스 저장 후 필터링해야 합니다.
+            if (businessBaseInfoList.get(0).getResultCode().equals("00")) {
+                List<BusinessBaseInfo.Item> items =  businessBaseInfoList.get(1).getItems().stream()
+                        .sorted(Comparator.comparing(BusinessBaseInfo.Item::getCreatedDate).reversed())
+                        .toList();
+                recentYearAndMonth = items.get(0).getCreatedDate();
+                return items.get(0).getSequenceNumber();
+            }
+        } catch (IOException e) {
+            return 0;
+        }
+        return 0;
+    }
+
+    private String buildBusinessBaseInfoUrl(List<String> queryParams) {
+        return UriComponentsBuilder.fromHttpUrl(API_BASE_URL + BUSINESS_BASE_INFO_LIST_API_PATH)
+                .queryParam("serviceKey", apiConfig.getDataGoKrServiceKey())
+                .queryParam("bzowr_rgst_no", queryParams.get(0))
+                .queryParam("wkpl_nm", URLEncoder.encode(queryParams.get(1), StandardCharsets.UTF_8))
+                .queryParam("pageNo", queryParams.get(2))
+                .queryParam("numOfRows", queryParams.get(3))
+                .build().toString();
+    }
+
+    private void requestBusinessDetailInfo(int sequenceNumber) {
+        String url = buildBusinessDetailInfoUrl(sequenceNumber);
+        var xmlMapper = new XmlMapper();
+        try {
+            businessDetailInfo = xmlMapper.readValue(new URL(url), BusinessDetailInfo.class);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String buildBusinessDetailInfoUrl(int sequenceNumber) {
+        return UriComponentsBuilder.fromHttpUrl(API_BASE_URL + BUSINESS_DETAIL_PER_MONTH_API_PATH)
+                .queryParam("serviceKey", apiConfig.getDataGoKrServiceKey())
+                .queryParam("seq", sequenceNumber)
+                .build().toString();
+    }
+
+    private void requestJoinLeaveInfo(int sequenceNumber) {
+        String url = buildJoinLeaveInfoUrl(sequenceNumber);
+        var xmlMapper = new XmlMapper();
+        try {
+            joinLeaveInfo = xmlMapper.readValue(new URL(url), JoinLeaveInfo.class);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String buildJoinLeaveInfoUrl(int sequenceNumber) {
+        return UriComponentsBuilder.fromHttpUrl(API_BASE_URL + EMPLOYEE_JOIN_LEAVE_PER_MONTH_API_PATH)
+                .queryParam("serviceKey", apiConfig.getDataGoKrServiceKey())
+                .queryParam("seq", sequenceNumber)
+                .build().toString();
+    }
+
+}

--- a/src/main/java/com/juniorok/juniorok/openapi/dto/BusinessBaseInfo.java
+++ b/src/main/java/com/juniorok/juniorok/openapi/dto/BusinessBaseInfo.java
@@ -1,0 +1,67 @@
+package com.juniorok.juniorok.openapi.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Component
+@JsonRootName(value = "response")
+public class BusinessBaseInfo {
+
+    private String returnAuthMsg;
+    private String returnReasonCode;
+    private String errMsg;
+
+    private String resultCode;
+    private String resultMsg;
+
+    private int numOfRows;
+    private int pageNo;
+    private int totalCount;
+
+    @JsonProperty(value = "items")
+    List<Item> items;
+
+    @Getter
+    public static class Item {
+        @JsonProperty(value = "dataCrtYm")
+        int createdDate; // YYYYMM
+
+        @JsonProperty(value = "seq")
+        int sequenceNumber; // 식별번호
+
+        @JsonProperty(value = "wkplNm")
+        String companyName; // 사업장명
+
+        @JsonProperty(value = "bzowrRgstNo")
+        String businessNumber; // 사업자등록번호
+
+        @JsonProperty(value = "wkplRoadNmDtlAddr")
+        String address; // 사업장도로명상세주소
+
+        @JsonProperty(value = "wkplJnngStcd")
+        int joinPensionStatusCode; //사업장가입상태코드(1:등록, 2:탈퇴)
+
+        @JsonProperty(value = "wkplStylDvcd")
+        int companyType; // 사업장형태구분코드(1:법인, 2:개인)
+
+        @JsonProperty(value = "ldongAddrMgplDgCd")
+        int stateCode; // 법정동주소광역시도코드
+
+        @JsonProperty(value = "ldongAddrMgplSgguCd")
+        int cityCode; // 법정동주소시군구코드
+
+        @JsonProperty(value = "ldongAddrMgplSgguEmdCd")
+        int dongCode; // 법정동주소읍면동코드
+    }
+
+}

--- a/src/main/java/com/juniorok/juniorok/openapi/dto/BusinessDetailInfo.java
+++ b/src/main/java/com/juniorok/juniorok/openapi/dto/BusinessDetailInfo.java
@@ -1,0 +1,86 @@
+package com.juniorok.juniorok.openapi.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Component
+@JsonRootName(value = "response")
+public class BusinessDetailInfo {
+
+    private Header header;
+
+    @Getter
+    public static class Header {
+        private String resultCode;
+        private String resultMsg;
+
+        private String returnAuthMsg;
+        private String returnReasonCode;
+        private String errMsg;
+    }
+
+    private Body body;
+
+    @Getter
+    public static class Body {
+
+        private Item item;
+
+        @Getter
+        public static class Item {
+            @JsonProperty(value = "vldtVlKrnNm")
+            String vldtVlKrnNm; // 사업장업종코드명(예. 응용 소프트웨어 개발 및 공급업)
+
+            @JsonProperty(value = "adptDt")
+            Date adptDt; // 사업장등록일
+
+            @JsonProperty(value = "scsnDt")
+            Date scsnDt; // 사업장탈퇴일
+
+            @JsonProperty(value = "jnngpCnt")
+            int employees; // 가입자수
+
+            @JsonProperty(value = "crrmmNtcAmt")
+            long monthlyAmount; // 당월고지금액
+
+            @JsonProperty(value = "wkplNm")
+            String companyName; // 사업장명
+
+            @JsonProperty(value = "bzowrRgstNo")
+            String bzowrRgstNo; // 사업자등록번호
+
+            @JsonProperty(value = "wkplRoadNmDtlAddr")
+            String address; // 사업장도로명상세주소
+
+            @JsonProperty(value = "wkplJnngStcd")
+            int joinPensionStatusCode; //사업장가입상태코드(1:등록, 2:탈퇴)
+
+            @JsonProperty(value = "ldongAddrMgplDgCd")
+            int stateCode; // 법정동주소광역시도코드
+
+            @JsonProperty(value = "ldongAddrMgplSgguCd")
+            int cityCode; // 법정동주소시군구코드
+
+            @JsonProperty(value = "ldongAddrMgplSgguEmdCd")
+            int dongCode; // 법정동주소읍면동코드
+
+            @JsonProperty(value = "wkplStylDvcd")
+            int companyType; // 사업장형태구분코드(1:법인, 2:개인)
+
+            @JsonProperty(value = "wkplIntpCd")
+            int wkplIntpCd; // 사업업종코드(국세청 업종코드 참조)
+        }
+
+    }
+
+}

--- a/src/main/java/com/juniorok/juniorok/openapi/dto/JoinLeaveInfo.java
+++ b/src/main/java/com/juniorok/juniorok/openapi/dto/JoinLeaveInfo.java
@@ -1,0 +1,55 @@
+package com.juniorok.juniorok.openapi.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Component
+@JsonRootName(value = "response")
+public class JoinLeaveInfo {
+
+    private Header header;
+
+    @Getter
+    public static class Header {
+        private String resultCode;
+        private String resultMsg;
+
+        private String returnAuthMsg;
+        private String returnReasonCode;
+        private String errMsg;
+    }
+
+    private Body body;
+
+    @Getter
+    public static class Body {
+
+        private int numOfRows;
+        private int pageNo;
+        private int totalCount;
+
+        private Items items;
+
+        @Getter
+        public static class Items {
+            private Item item;
+
+            @Getter
+            public static class Item {
+                @JsonProperty(value = "nwAcqzrCnt")
+                int join ; // 월별취업자수
+
+                @JsonProperty(value = "lssJnngpCnt")
+                int leave; // 월별퇴사자수
+            }
+        }
+    }
+}

--- a/src/main/java/com/juniorok/juniorok/repository/CompanyRepository.java
+++ b/src/main/java/com/juniorok/juniorok/repository/CompanyRepository.java
@@ -1,21 +1,21 @@
 package com.juniorok.juniorok.repository;
 
 import com.juniorok.juniorok.domain.Company;
+import com.juniorok.juniorok.dto.Address;
 import com.juniorok.juniorok.dto.Benefit;
-import org.apache.ibatis.annotations.Arg;
+import com.juniorok.juniorok.dto.JoinLeave;
 import org.apache.ibatis.annotations.Mapper;
-import org.apache.ibatis.annotations.Results;
-import org.apache.ibatis.annotations.Select;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Optional;
 
 @Mapper
 @Repository
 public interface CompanyRepository {
 
     void save(Company company);
+    void saveAddress(Address address);
+    void saveJoinLeave(JoinLeave joinLeave);
     long findIdByName(String name);
 
     List<Benefit> findAllBenefitTags();

--- a/src/main/java/com/juniorok/juniorok/service/CompanyService.java
+++ b/src/main/java/com/juniorok/juniorok/service/CompanyService.java
@@ -1,8 +1,11 @@
 package com.juniorok.juniorok.service;
 
 import com.juniorok.juniorok.domain.Company;
+import com.juniorok.juniorok.dto.Address;
 import com.juniorok.juniorok.dto.Benefit;
+import com.juniorok.juniorok.dto.JoinLeave;
 import com.juniorok.juniorok.form.PostForm;
+import com.juniorok.juniorok.openapi.NationalPensionApi;
 import com.juniorok.juniorok.repository.CompanyRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -10,25 +13,59 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-
 @RequiredArgsConstructor
 @Service
 public class CompanyService {
 
     private final CompanyRepository companyRepository;
+    private final NationalPensionApi nationalPensionApi;
 
     @Transactional
     public long saveCompany(PostForm postForm) {
-        companyRepository.save(extractCompanyInfo(postForm));
-        return companyRepository.findIdByName(postForm.companyName());
+        Company company = extractCompanyInfo(postForm);
+        long businessNumber = company.getBusinessNumber();
+        if (businessNumber > 1_000_000_000) { // 사업자번호는 10자리
+            company.setEmployees(nationalPensionApi.getRecentEmployees(postForm.businessNumber(), postForm.companyName()));
+            company.setAvgSalary(nationalPensionApi.getRecentAverageSalary(postForm.businessNumber(), postForm.companyName()));
+        }
+        companyRepository.save(company);
+        long companyId = companyRepository.findIdByName(company.getName());
+        company.setId(companyId);
+        if (businessNumber > 1_000_000_000) {
+            companyRepository.saveAddress(extractAddressInfo(company));
+            companyRepository.saveJoinLeave(extractJoinLeaveInfo(company));
+        }
+        return companyId;
     }
 
     private Company extractCompanyInfo(PostForm postForm) {
         return Company.builder()
                 .name(postForm.companyName())
                 .techBlog(postForm.techBlogUrl().toString())
-                .employees(postForm.employees())
                 .developers(postForm.developers())
+                .businessNumber(postForm.businessNumber())
+                .build();
+    }
+
+    private Address extractAddressInfo(Company company) {
+        String[] address = nationalPensionApi.getAddress(company.getBusinessNumber(), company.getName()).split("\\s");
+        return Address.builder()
+                .company(company)
+                .state(address[0])
+                .city(address[1])
+                .others(address[2])
+                .build();
+    }
+
+    private JoinLeave extractJoinLeaveInfo(Company company) {
+        int join = nationalPensionApi.getJoinCount(company.getBusinessNumber(), company.getName());
+        int leave = nationalPensionApi.getLeaveCount(company.getBusinessNumber(), company.getName());
+        return JoinLeave.builder()
+                .company(company)
+                .year(nationalPensionApi.getRecentYearAndMonth()/100)
+                .month(nationalPensionApi.getRecentYearAndMonth()%100)
+                .join(join)
+                .leave(leave)
                 .build();
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,3 +21,6 @@ spring.security.oauth2.client.registration.github.scope=${GITHUB_SCOPE}
 #thymeleaf
 spring.thymeleaf.render-hidden-markers-before-checkboxes=true
 # https://github.com/thymeleaf/thymeleaf-spring/issues/178
+
+#data.go.kr
+data.go.kr.service_key=${DATA_GO_KR_SERVICE_KEY}

--- a/src/main/resources/mapper/company-mapper.xml
+++ b/src/main/resources/mapper/company-mapper.xml
@@ -75,5 +75,15 @@
     <select id="findAllBenefitTags" resultMap="benefitResultMap">
         SELECT * FROM benefits;
     </select>
+    
+    <insert id="saveAddress" parameterType="com.juniorok.juniorok.dto.Address">
+        INSERT INTO addresses (company_id, state, city, others)
+        VALUES (#{company.id}, #{state}, #{city}, #{others})
+    </insert>
+
+    <insert id="saveJoinLeave" parameterType="com.juniorok.juniorok.dto.JoinLeave">
+        INSERT INTO join_leaves (company_id, year, month, `join`, `leave`)
+        VALUES (#{company.id}, #{year}, #{month}, #{join}, #{leave})
+    </insert>
 
 </mapper>

--- a/src/main/resources/mapper/company-mapper.xml
+++ b/src/main/resources/mapper/company-mapper.xml
@@ -39,7 +39,8 @@
         <if test="employees != null" >employees,</if>
         <if test="developers != null" >developers,</if>
         <if test="revenue != null" >revenue,</if>
-        <if test="avgSalary != null" >avg_salary</if>)
+        <if test="avgSalary != null" >avg_salary,</if>
+        <if test="businessNumber != null" >business_number</if>)
         VALUES (
         <if test="name != null" >#{name},</if>
         <if test="ceo != null" >#{ceo},</if>
@@ -49,7 +50,8 @@
         <if test="employees != null" >#{employees},</if>
         <if test="developers != null" >#{developers},</if>
         <if test="revenue != null" >#{revenue},</if>
-        <if test="avgSalary != null" >#{avgSalary}</if>)
+        <if test="avgSalary != null" >#{avgSalary},</if>
+        <if test="businessNumber != null" >#{businessNumber}</if>)
         ON DUPLICATE KEY UPDATE
         <if test="ceo != null" >ceo = #{ceo},</if>
         <if test="introduction != null" >introduction = #{introduction},</if>

--- a/src/main/resources/mapper/post-mapper.xml
+++ b/src/main/resources/mapper/post-mapper.xml
@@ -16,8 +16,8 @@
         <result property="recommended" column="recommended" />
         <result property="deleted" column="deleted" />
         <association property="company" javaType="com.juniorok.juniorok.domain.Company" >
-            <id property="id" column="id" />
-            <result property="name" column="name" />
+            <id property="id" column="company_id" />
+            <result property="name" column="company_name" />
             <result property="ceo" column="ceo" />
             <result property="introduction" column="introduction" />
             <result property="homepage" column="homepage" />
@@ -80,7 +80,7 @@
 
     <select id="findPage" parameterType="int" resultMap="postResultMap">
         SELECT p.id, p.position, p.location, p.recommended, p.deadline,
-               c.id, c.name, c.avg_salary
+               c.id AS company_id, c.name AS company_name, c.avg_salary / 10000 AS avg_salary
         FROM posts AS p
         JOIN companies AS c ON p.company_id = c.id
         LIMIT #{param1}, #{param2}

--- a/src/main/resources/templates/posts/post_list_card.html
+++ b/src/main/resources/templates/posts/post_list_card.html
@@ -10,12 +10,13 @@
 </head>
 <body>
 
-<th:block th:fragment="post_list_card" th:each="post : ${posts}">
+<th:block th:fragment="post_list_card" th:each="post, s : ${posts}">
   <div class="row mb-3">
     <div class="col-2"></div>
     <div class="col-8 pop-on-hover" data-bs-toggle="modal" data-bs-target="#postDetailsModal">
       <div class="card rounded-5 shadow" style="background: #99b3dd; cursor: pointer;">
         <div class="row card-body">
+          <input type="hidden" th:id="|companyId${s.count}|" th:value="${post.getCompany().getId()}">
           <div class="col-2 d-flex align-items-center justify-content-center">
             <img class="rounded-circle" style="width: 60px" alt="회사 로고" th:src="@{/img/company.svg}" />
           </div>
@@ -25,7 +26,8 @@
             <div class="row">
               <div>
                 <span class="btn text-white rounded-5 py-0 disabled">경기</span>
-                <span class="btn text-white rounded-5 py-0 disabled">평균연봉: 4000</span>
+                <span th:if="${post.getCompany().getAvgSalary() != null}"
+                      class="btn text-white rounded-5 py-0 disabled" th:text="|평균연봉: ${post.getCompany().getAvgSalary()}|"></span>
                 <span class="btn text-white rounded-5 py-0 disabled">Java</span>
                 <span class="btn text-white rounded-5 py-0 disabled">Spring</span>
                 <span class="btn text-white rounded-5 py-0 disabled">Docker</span>
@@ -33,7 +35,12 @@
             </div>
           </div>
           <div class="col-1 d-flex align-items-center justify-content-center text-white">
-            <h5 th:text="|D-${T(java.time.temporal.ChronoUnit).DAYS.between(T(java.time.LocalDate).now(), post.deadline)}|"></h5>
+            <th:block th:if="post.deadline != null">
+              <h5 th:text="|D-${T(java.time.temporal.ChronoUnit).DAYS.between(T(java.time.LocalDate).now(), post.deadline)}|"></h5>
+            </th:block>
+            <th:block th:if="post.deadline == null">
+              <h5 th:text="상시"></h5>
+            </th:block>
           </div>
           <div class="col-1 d-flex align-items-center justify-content-center">
             <button class="btn btn-close btn-close-white"></button>

--- a/src/main/resources/templates/posts/post_write.html
+++ b/src/main/resources/templates/posts/post_write.html
@@ -20,6 +20,10 @@
             <label for="companyName">회사이름</label>
         </div>
         <div class="form-floating mb-3">
+            <input type="text" class="form-control" id="businessNumber" placeholder="사업자등록번호" name="businessNumber">
+            <label for="businessNumber">사업자등록번호</label>
+        </div>
+        <div class="form-floating mb-3">
             <input type="text" class="form-control" id="position" placeholder="포지션" name="position">
             <label for="position">포지션</label>
         </div>


### PR DESCRIPTION
국민연금 API 연동했습니다. 직원수, 평균연봉 추정치, 최근 1개월 입퇴사자수 정도만 가져오도록 했습니다.

일단 마이페이지에서만 표시해봤습니다.

![image](https://github.com/kdtkdt/juniorok/assets/135004614/b491433e-c352-4240-8238-ba2961587f29)

API가 너무 더러워서... 중복 검사라던가 예외처리가 거의 안돼있습니다.

사업자번호를 입력해야 데이터를 가져올 수 있습니다. 그리고 사업자번호는 `-` 는 빼고, 입력해야됩니다.

사업자번호를 앞의 6자리만 받는데, 사업자번호 6자리는 중복되는 사업자가 많기 때문에, 회사 법인명을 최대한 정확하게 입력해줘야 합니다. 안그러면 이상한 데이터 불러옵니다... API가 문제가 많아서 애초에 실시간으로 처리할 데이터는 아닌거 같네요.